### PR TITLE
Add compatibility for PBSPro (issue #8)

### DIFF
--- a/{{cookiecutter.profile_name}}/pbspro_status.py
+++ b/{{cookiecutter.profile_name}}/pbspro_status.py
@@ -15,17 +15,25 @@ try:
         shell=True,
     )
 
+    tracejob = subprocess.run(
+        "tracejob -n 1 {}".format(jobid),
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        shell=True
+    )
+
     jsondoc = json.loads(res.stdout.decode())
     job_state = jsondoc["Jobs"][jobid]["job_state"]
 
-    if job_state == "C":
-        exit_status = jsondoc["Jobs"][jobid]["Exit_status"]
-        if exit_status == "0":
+    if job_state:
+        print("running")
+    else:
+        exit_status_0 = "Exit_status=0" in tracejob.stdout
+        if exit_status_0:
             print("success")
         else:
             print("failed")
-    else:
-        print("running")
 
 except (subprocess.CalledProcessError, IndexError, KeyboardInterrupt) as e:
     print("failed")

--- a/{{cookiecutter.profile_name}}/pbspro_status.py
+++ b/{{cookiecutter.profile_name}}/pbspro_status.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+import sys
+import subprocess
+import json
+
+jobid = sys.argv[1]
+
+try:
+    res = subprocess.run(
+        "qstat -f -F json -x {}".format(jobid),
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        shell=True,
+    )
+
+    jsondoc = json.loads(res.stdout.decode())
+    job_state = jsondoc["Jobs"][jobid]["job_state"]
+
+    if job_state == "C":
+        exit_status = jsondoc["Jobs"][jobid]["Exit_status"]
+        if exit_status == "0":
+            print("success")
+        else:
+            print("failed")
+    else:
+        print("running")
+
+except (subprocess.CalledProcessError, IndexError, KeyboardInterrupt) as e:
+    print("failed")

--- a/{{cookiecutter.profile_name}}/scheduler.py
+++ b/{{cookiecutter.profile_name}}/scheduler.py
@@ -157,7 +157,7 @@ else:
         match = re.search(r"Job <(\d+)> is submitted", res)
         jobid = match.group(1)
 
-    elif system == "pbs":
+    elif system == "pbs" or system == "pbspro":
         jobid = res.strip().split(".")[0]
 
     else:


### PR DESCRIPTION
This PR should make the profile compatible with PBSPro, which uses Json instead of XML for the job status reports (obtained through `qstat -x -f json`; issue #8 )

I was able to test it only on my system at the moment, where it seems to fail when jobs are completed (as the job gets removed from the `qstat` output immediately). I don't know if it is a quirk of my cluster or general to PBSPro, so ideally it would need some additional testing before merging.